### PR TITLE
中山さんが気になったところ諸々の修正

### DIFF
--- a/docs/Setup/add_providers.md
+++ b/docs/Setup/add_providers.md
@@ -29,13 +29,9 @@ sidebar_position: 2
 
 ## 4. 手順
 
+本手順はplanets-lib フォルダにて行う。
+
 ### 4.1. Docker の実行（localY）
-
-1.  GitBash(Mac 版の場合はターミナル)を起動し、plat-release フォルダに移動
-
-    ```
-    # cd ./plat-release
-    ```
 
 1.  シェルを起動し、Docker のデータ初期化を行う
 

--- a/docs/Setup/build.md
+++ b/docs/Setup/build.md
@@ -56,13 +56,9 @@ sidebar_position: 1
 
 ## 5. 手順
 
+本手順はplanets-lib フォルダにて行う。
+
 ### 5.1. Docker の実行（remote）
-
-1.  GitBash(Mac 版の場合はターミナル)を起動し、plat-release フォルダに移動
-
-    ```
-    # cd ./plat-release
-    ```
 
 1.  シェルを起動し、Docker の起動を行う
 

--- a/docs/Setup/init_docker.md
+++ b/docs/Setup/init_docker.md
@@ -20,13 +20,13 @@ sidebar_position: 3
    - localX
 
    ```
-   # docker stop localX_plat-db localX_keycloak-db localX_openfructos-db localX_openfructos-audit-db localX_rabbitmq localX_key-cloak localX_openfructos-tomcat localX_plat-gateway localX_plat-api localX_plat-mq localX_plat-sync localX_plat-autoapproval localX_plat-cleaning
+   # docker stop localX_plat-db localX_keycloak-db localX_openfructos-db localX_openfructos-audit-db localX_rabbitmq localX_keycloak localX_openfructos-tomcat localX_plat-gateway localX_plat-api localX_plat-mq localX_plat-sync localX_plat-autoapproval localX_plat-cleaning
    ```
 
    - localY
 
    ```
-   # docker stop localY_plat-db localY_keycloak-db localY_openfructos-db localY_openfructos-audit-db localY_rabbitmq localY_key-cloak localY_openfructos-tomcat localY_plat-gateway localY_plat-api localY_plat-mq localY_plat-sync localY_plat-autoapproval localY_plat-cleaning
+   # docker stop localY_plat-db localY_keycloak-db localY_openfructos-db localY_openfructos-audit-db localY_rabbitmq localY_keycloak localY_openfructos-tomcat localY_plat-gateway localY_plat-api localY_plat-mq localY_plat-sync localY_plat-autoapproval localY_plat-cleaning
    ```
 
 1. Docker のイメージを削除
@@ -40,13 +40,13 @@ sidebar_position: 3
    - localX
 
    ```
-   # docker rm localX_plat-db localX_keycloak-db localX_openfructos-db localX_openfructos-audit-db localX_rabbitmq localX_key-cloak localX_openfructos-tomcat localX_plat-gateway localX_plat-api localX_plat-mq localX_plat-sync localX_plat-autoapproval localX_plat-cleaning
+   # docker rm localX_plat-db localX_keycloak-db localX_openfructos-db localX_openfructos-audit-db localX_rabbitmq localX_keycloak localX_openfructos-tomcat localX_plat-gateway localX_plat-api localX_plat-mq localX_plat-sync localX_plat-autoapproval localX_plat-cleaning
    ```
 
    - localY
 
    ```
-   # docker rm localY_plat-db localY_keycloak-db localY_openfructos-db localY_openfructos-audit-db localY_rabbitmq localY_key-cloak localY_openfructos-tomcat localY_plat-gateway localY_plat-api localY_plat-mq localY_plat-sync localY_plat-autoapproval localY_plat-cleaning
+   # docker rm localY_plat-db localY_keycloak-db localY_openfructos-db localY_openfructos-audit-db localY_rabbitmq localY_keycloak localY_openfructos-tomcat localY_plat-gateway localY_plat-api localY_plat-mq localY_plat-sync localY_plat-autoapproval localY_plat-cleaning
    ```
 
    - 以下コマンドを実行し、ローカル DB データファイルを削除

--- a/docs/Usage/operation_check.md
+++ b/docs/Usage/operation_check.md
@@ -20,11 +20,11 @@ PLAT 環境の構築後に動作確認をするための手順を記載する。
 1. Postman を起動し[File] [Import] を押下する。  
    ![image.png](../.attachments/image-1b663dd4-3541-409a-bf16-64ffc8dda1d7.png)
 
-1. [Upload Files] を押下し、処理定義（2.セットアップ手順/3.利用手順/contents 配下）のファイルをインポートする。
+1. [Upload Files] を押下し、処理定義（planets-lib/postman/collection 配下）のファイルをインポートする。
 
    - PLAT 疎通確認.postman_collection.json
 
-1. [Upload Files] を押下し、環境変数（2.セットアップ手順/3.利用手順/contents 配下）のファイルをインポートする。
+1. [Upload Files] を押下し、環境変数（planets-lib/postman/environment 配下）のファイルをインポートする。
    - PLAT リリース環境.postman_environment.json
 
 ### 3.2. KeyCloak の設定
@@ -82,3 +82,5 @@ PLAT 環境の構築後に動作確認をするための手順を記載する。
 4. 組織一覧を取得  
    Postman の [PLAT 疎通確認] - [LocalX] - [⑥PRV_ORG_001.【取得】文書情報が存在する医療機関リスト] を開き、Send ボタンを押下する。  
    ※ここで正常にレスポンスが返ってくれば plat-gateway → KeyCloak → plat-api(LocalX) → plat-api(Remote) → OpenFRUCtoS(Remote)の一気通貫が確認完了。
+   
+※以上の手順を行うと、KeyCloak(Realm = 1310000001L) にadminユーザとスタッフが1人ずつ登録され、PLATのDBにスタッフが1人登録される。

--- a/docs/Usage/operation_check.md
+++ b/docs/Usage/operation_check.md
@@ -86,4 +86,4 @@ PLAT 環境の構築後に動作確認をするための手順を記載する。
    
 ※上記の手順を行うと、クリニックXにadminユーザとスタッフが1人ずつ登録される。
 ※クリニックYにおいて上記の手順を行う場合、管理コンソールからユーザを登録（KeyCloakのレルムは1310000002）し、
- Postman の [PLAT 疎通確認] - [LocalX]のPre-request Scripts にLocalX , ClinixXと記載があるパラメタ名をLocalY, ClinixYに変更する。
+ Postman の [PLAT 疎通確認] - [LocalX]のPre-request Scripts にLocalX , ClinicXと記載があるパラメタ名をLocalY, ClinicYに変更する。

--- a/docs/Usage/operation_check.md
+++ b/docs/Usage/operation_check.md
@@ -20,11 +20,12 @@ PLAT 環境の構築後に動作確認をするための手順を記載する。
 1. Postman を起動し[File] [Import] を押下する。  
    ![image.png](../.attachments/image-1b663dd4-3541-409a-bf16-64ffc8dda1d7.png)
 
-1. [Upload Files] を押下し、処理定義（planets-lib/postman/collection 配下）のファイルをインポートする。
+2. [Upload Files] を押下し、処理定義（planets-lib/postman/collection 配下）のファイルをインポートする。
 
    - PLAT 疎通確認.postman_collection.json
 
-1. [Upload Files] を押下し、環境変数（planets-lib/postman/environment 配下）のファイルをインポートする。
+3. [Upload Files] を押下し、環境変数（planets-lib/postman/environment 配下）のファイルをインポートする。
+
    - PLAT リリース環境.postman_environment.json
 
 ### 3.2. KeyCloak の設定
@@ -83,4 +84,6 @@ PLAT 環境の構築後に動作確認をするための手順を記載する。
    Postman の [PLAT 疎通確認] - [LocalX] - [⑥PRV_ORG_001.【取得】文書情報が存在する医療機関リスト] を開き、Send ボタンを押下する。  
    ※ここで正常にレスポンスが返ってくれば plat-gateway → KeyCloak → plat-api(LocalX) → plat-api(Remote) → OpenFRUCtoS(Remote)の一気通貫が確認完了。
    
-※以上の手順を行うと、KeyCloak(Realm = 1310000001L) にadminユーザとスタッフが1人ずつ登録され、PLATのDBにスタッフが1人登録される。
+※上記の手順を行うと、クリニックXにadminユーザとスタッフが1人ずつ登録される。
+※クリニックYにおいて上記の手順を行う場合、管理コンソールからユーザを登録（KeyCloakのレルムは1310000002）し、
+ Postman の [PLAT 疎通確認] - [LocalX]のPre-request Scripts にLocalX , ClinixXと記載があるパラメタ名をLocalY, ClinixYに変更する。

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -34,6 +34,11 @@ sidebar_position: 2
 
 ![image.png](.attachments/image-9cccddd2-45b1-4469-822b-1da946e5888c.png)
 
+| 区分    | 対象      | DNS名/サーバ名                                        | パブリックIP  | プライベートIP |
+|:----|---------|--------------------------------------------------| ------- |----------|
+| Local | ClinicX | plat-poc-local-vm01.japaneast.cloudapp.azure.com |  20.89.137.82  | 10.1.0.4 |
+|       | ClinicY | plat-poc-local-vm02.japaneast.cloudapp.azure.com |  20.78.67.124  | 10.1.0.6 |
+
 ## 4. ミドルウェアの役割
 
 ### 4.1. Keycloak

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -34,10 +34,15 @@ sidebar_position: 2
 
 ![image.png](.attachments/image-9cccddd2-45b1-4469-822b-1da946e5888c.png)
 
-| 区分    | 対象      | DNS名/サーバ名                                        | パブリックIP  | プライベートIP |
-|:----|---------|--------------------------------------------------| ------- |----------|
-| Local | ClinicX | plat-poc-local-vm01.japaneast.cloudapp.azure.com |  20.89.137.82  | 10.1.0.4 |
-|       | ClinicY | plat-poc-local-vm02.japaneast.cloudapp.azure.com |  20.78.67.124  | 10.1.0.6 |
+| 区分     | 対象      | APIサーバ                | Gatewayサーバ            | OpenFRUCtoSサーバ        | KeyCloakサーバ            |
+|:-------|---------|-----------------------|-----------------------|-----------------------|------------------------|
+| Local  | ClinicX | http://localhost:8181 | http://localhost:8182 | http://localhost:9083 | http://localhost:8184  |
+|        | ClinicY | http://localhost:8281 | http://localhost:8282 | http://localhost:9085 | http://localhost:8284  |
+| Remote | Remote  | http://localhost:8081 | http://localhost:8082 |                       | http://localhost:8084  |
+|        | RemoteX |                       |                       | http://localhost:9082 |                        |
+|        | RemoteY |                       |                       | http://localhost:9084 |                        |
+|        | Patient |                       |                       | http://localhost:9081 |                        |
+
 
 ## 4. ミドルウェアの役割
 


### PR DESCRIPTION
1. 「全体構成」local X/Y, remoteのアクセス情報、ポート番号やURLは不要？https://planets-org.github.io/planets-doc/docs/overview
1. 「新規に基盤を構築する」「医療機関を追加する」▶︎「GitBash(Mac 版の場合はターミナル)を起動し、plat-release フォルダに移動」の処理は不要では？
1. 「環境の初期化手順」→「起動中の Docker コンテナを停止」→「localX / Y」でkeycloakがkey-cloakになっている
1. postman手順実行後、どういう状態になっているのかわかりづらい
　→local Xにadmin権限者と、スタッフが１名ずつ登録され、個人ユーザーは誰もいない状態？local Yは？

以上について修正を行いました。