### PR TITLE
#1675_ リクエストとレスポンスのサンプルの登録者名修正

### DIFF
--- a/docs/API/API_list/providers/2.7.スタッフ管理/PRV_STF_001：【登録】スタッフ情報.md
+++ b/docs/API/API_list/providers/2.7.スタッフ管理/PRV_STF_001：【登録】スタッフ情報.md
@@ -117,8 +117,8 @@ PLAT 上にスタッフ情報を登録する。
           "valueCode": "IDE"
         }
       ],
-      "family": "田中",
-      "given": ["一郎"]
+      "family": "山本",
+      "given": ["太郎"]
     },
     {
       "extension": [
@@ -127,8 +127,8 @@ PLAT 上にスタッフ情報を登録する。
           "valueCode": "SYL"
         }
       ],
-      "family": "タナカ",
-      "given": ["イチロウ"]
+      "family": "ヤマモト",
+      "given": ["タロウ"]
     }
   ],
   "identifier": [

--- a/docs/API/API_list/providers/2.7.スタッフ管理/PRV_STF_003：【登録】スタッフ情報（認証情報まで一括登録）.md
+++ b/docs/API/API_list/providers/2.7.スタッフ管理/PRV_STF_003：【登録】スタッフ情報（認証情報まで一括登録）.md
@@ -123,8 +123,8 @@ PLAT 上にスタッフ情報を登録し、同時に認証情報を作成し紐
           "valueCode": "IDE"
         }
       ],
-      "family": "田中",
-      "given": ["一郎"]
+      "family": "山本",
+      "given": ["太郎"]
     },
     {
       "extension": [
@@ -133,8 +133,8 @@ PLAT 上にスタッフ情報を登録し、同時に認証情報を作成し紐
           "valueCode": "SYL"
         }
       ],
-      "family": "タナカ",
-      "given": ["イチロウ"]
+      "family": "ヤマモト",
+      "given": ["タロウ"]
     }
   ],
   "identifier": [


### PR DESCRIPTION
以下のAPIのドキュメントサイトにおいて、
サンプルでのリクエストとレスポンスの登録者名が一致していなかった。
そこで、レスポンスの登録者名をリクエストのものに揃えた。

該当API
・PRV_STF_001
・PRV_STF_003

【タスク】
以下のAPIのレスポンスの登録者をリクエストのものに揃える。
・PRV_STF_001
・PRV_STF_003　

【完了条件】
・確認
・マージ